### PR TITLE
Fix shield-24 dimensions

### DIFF
--- a/symbol-library/src/shield-24.svg
+++ b/symbol-library/src/shield-24.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 27 27" height="27" width="27">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" height="24" width="24">
     <title>shield-24.svg</title>
-    <rect fill="none" x="0" y="0" width="27" height="27"></rect>
-    <rect x="0" y="0" width="27" height="27" rx="4" ry="4"></rect>
+    <rect fill="none" x="0" y="0" width="24" height="24"></rect>
+    <rect x="0" y="0" width="24" height="24" rx="4" ry="4"></rect>
 </svg>


### PR DESCRIPTION
Seems to me that it should be `24×24`, but maybe I'm misunderstanding something? I didn't adjust the curve of the corners, since I see that the radius is `4` in both variants.